### PR TITLE
Fix TypeScript examples HTTP client error

### DIFF
--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -15,8 +15,8 @@ import * as os from 'os';
 function getInstallSalt(): string {
     const storageKey = 'pdfdancer_install_salt';
 
-    // Check if we're in a browser environment
-    if (typeof localStorage !== 'undefined') {
+    // Check if we're in a browser environment with functional localStorage
+    if (typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function') {
         let salt = localStorage.getItem(storageKey);
         if (!salt) {
             salt = crypto.randomBytes(16).toString('hex');


### PR DESCRIPTION
The localStorage check now verifies both that localStorage exists AND that localStorage.getItem is a function before attempting to use it. This fixes the 'localStorage.getItem is not a function' error in Node.js environments where localStorage might be defined but not properly initialized.