### PR TITLE
Support PDF filepath string in PDFDancer.open

### DIFF
--- a/src/__tests__/e2e/open-input-types.test.ts
+++ b/src/__tests__/e2e/open-input-types.test.ts
@@ -1,0 +1,120 @@
+/**
+ * E2E tests for PDFDancer.open() with different input types
+ */
+
+import {PDFDancer} from '../../index';
+import {getBaseUrl, readToken, serverUp} from './test-helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('PDFDancer.open() Input Types E2E Tests', () => {
+    let baseUrl: string;
+    let token: string;
+    const fixturesDir = path.resolve(__dirname, '../../../fixtures');
+    const testPdfPath = path.join(fixturesDir, 'Empty.pdf');
+
+    beforeAll(async () => {
+        baseUrl = getBaseUrl();
+        const tokenValue = readToken();
+
+        if (!await serverUp(baseUrl)) {
+            throw new Error(`PDFDancer server not reachable at ${baseUrl}; set PDFDANCER_BASE_URL or start server`);
+        }
+
+        if (!tokenValue) {
+            throw new Error('PDFDANCER_TOKEN not set and no token file found; set env or place jwt-token-*.txt in repo');
+        }
+
+        token = tokenValue;
+
+        // Verify test PDF exists
+        if (!fs.existsSync(testPdfPath)) {
+            throw new Error(`Test PDF not found at ${testPdfPath}`);
+        }
+    });
+
+    test('open PDF with string filepath', async () => {
+        // Test opening PDF with string filepath
+        const pdf = await PDFDancer.open(testPdfPath, token, baseUrl);
+
+        expect(pdf).toBeDefined();
+
+        // Verify the PDF was loaded correctly
+        const pages = await pdf.pages();
+        expect(pages).toBeDefined();
+        expect(Array.isArray(pages)).toBe(true);
+
+        // Can get bytes from the PDF
+        const bytes = await pdf.getBytes();
+        expect(bytes).toBeInstanceOf(Uint8Array);
+        expect(bytes.length).toBeGreaterThan(0);
+
+        // Verify PDF signature
+        const signature = String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]);
+        expect(signature).toBe('%PDF');
+    });
+
+    test('open PDF with Uint8Array (raw bytes)', async () => {
+        // Read PDF as bytes
+        const pdfBytes = new Uint8Array(fs.readFileSync(testPdfPath));
+
+        // Test opening PDF with Uint8Array
+        const pdf = await PDFDancer.open(pdfBytes, token, baseUrl);
+
+        expect(pdf).toBeDefined();
+
+        // Verify the PDF was loaded correctly
+        const pages = await pdf.pages();
+        expect(pages).toBeDefined();
+        expect(Array.isArray(pages)).toBe(true);
+
+        // Can get bytes from the PDF
+        const bytes = await pdf.getBytes();
+        expect(bytes).toBeInstanceOf(Uint8Array);
+        expect(bytes.length).toBeGreaterThan(0);
+
+        // Verify PDF signature
+        const signature = String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]);
+        expect(signature).toBe('%PDF');
+    });
+
+    test('both input types produce equivalent results', async () => {
+        // Open same PDF with filepath
+        const pdfFromPath = await PDFDancer.open(testPdfPath, token, baseUrl);
+        const pagesFromPath = await pdfFromPath.pages();
+
+        // Open same PDF with bytes
+        const pdfBytes = new Uint8Array(fs.readFileSync(testPdfPath));
+        const pdfFromBytes = await PDFDancer.open(pdfBytes, token, baseUrl);
+        const pagesFromBytes = await pdfFromBytes.pages();
+
+        // Both should have same number of pages
+        expect(pagesFromPath.length).toBe(pagesFromBytes.length);
+    });
+
+    test('open PDF with relative filepath', async () => {
+        // Test with a relative path
+        const relativePath = './fixtures/Empty.pdf';
+        const pdf = await PDFDancer.open(relativePath, token, baseUrl);
+
+        expect(pdf).toBeDefined();
+        const pages = await pdf.pages();
+        expect(pages).toBeDefined();
+    });
+
+    test('rejects invalid filepath', async () => {
+        const invalidPath = '/nonexistent/path/to/file.pdf';
+
+        await expect(PDFDancer.open(invalidPath, token, baseUrl))
+            .rejects
+            .toThrow(/PDF file not found|ENOENT/);
+    });
+
+    test('rejects empty Uint8Array', async () => {
+        const emptyBytes = new Uint8Array(0);
+
+        await expect(PDFDancer.open(emptyBytes, token, baseUrl))
+            .rejects
+            .toThrow(/PDF data cannot be empty/);
+    });
+});

--- a/src/pdfdancer_v1.ts
+++ b/src/pdfdancer_v1.ts
@@ -623,8 +623,18 @@ export class PDFDancer {
         return this;
     }
 
+    /**
+     * Opens a PDF document for manipulation.
+     *
+     * @param pdfData PDF data as Uint8Array (raw bytes) or string (filepath)
+     * @param token Authentication token (optional, can use PDFDANCER_TOKEN env var)
+     * @param baseUrl Base URL for the PDFDancer API (optional)
+     * @param timeout Request timeout in milliseconds (default: 60000)
+     * @param retryConfig Retry configuration (optional, uses defaults if not specified)
+     * @returns A PDFDancer client instance
+     */
     static async open(
-        pdfData: Uint8Array,
+        pdfData: Uint8Array | string,
         token?: string,
         baseUrl?: string,
         timeout?: number,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/__tests__"]
 }


### PR DESCRIPTION
- Updated PDFDancer.open() signature to accept both Uint8Array and string (filepath)
- The underlying implementation in _processPdfData already supported string filepaths
- Added comprehensive JSDoc documentation for the open() method
- Added E2E tests for both input types (string filepath and Uint8Array)
- Updated tsconfig.json to exclude test directories from build
- Type definitions now correctly reflect the dual input support

This enhancement allows users to call:
  - PDFDancer.open("lease-agreement.pdf") // filepath
  - PDFDancer.open(pdfBytes) // raw bytes (Uint8Array)